### PR TITLE
changed method name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ class ReactToken extends React.Component {
     window.addEventListener('click', this.onClick)
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.selected !== nextProps.selected) {
       this.setState({tokens: nextProps.selected})
     }


### PR DESCRIPTION
The deprecated method name has been changed according to docs https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path

This is related to issue https://github.com/dbslone/react-token/issues/4